### PR TITLE
商品購入機能実装後の表示機能追加実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,8 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path unless current_user == @item.user
+    redirect_to root_path unless current_user == @item.user && @item.order == nil
+
   end
 
   def update

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 
-                <%# 商品が売れていればsold outを表示しましょう %>
+                <% if item.order != nil %>
                 <div class='sold-out'>
                   <span>Sold Out!!</span>
                 </div>
-                <%# //商品が売れていればsold outを表示しましょう %>
+                <% end %>
 
               </div>
               <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,14 +24,14 @@
         <%= @item.shipping_fee_status.name %>
       </span>
     </div>
-<% if user_signed_in? %>
+<% if user_signed_in? && @item.order == nil %>
 
-  <% if current_user == @item.user && @item.order == nil %>
+  <% if current_user == @item.user %>
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
     
-    <% elsif @item.order == nil %>
+    <% else %>
     <%= link_to '購入画面に進む', item_order_index_path(@item.id) ,class:"item-red-btn"%>
     <% end %>
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -14,7 +14,7 @@
         <span>Sold Out!!</span>
       </div>
       <% end %>
-      
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -26,18 +26,16 @@
     </div>
 <% if user_signed_in? %>
 
-  <% if current_user == @item.user %>
+  <% if current_user == @item.user && @item.order == nil %>
     <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-    <% elsif '商品が出品中かどうか' %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    
+    <% elsif @item.order == nil %>
     <%= link_to '購入画面に進む', item_order_index_path(@item.id) ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
     <% end %>
 <% end %>
+
     <div class="item-explain-box">
       <span><%= @item.info %></span>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,13 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+
+      <% if @item.order != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
+      
     </div>
     <div class="item-price-box">
       <span class="item-price">


### PR DESCRIPTION
# What
*商品一覧ページにて売却済み商品に『sold out』を表示
*商品詳細ページにて売却済み商品に『sold out』を表示
*商品詳細ページにて売却済み商品は「編集・削除ボタン」「購入画面に進むボタン」を非表示
*出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移

# why
商品購入機能実装後の表示機能追加実装

https://gyazo.com/04734a4255a8c17ee54d3eacaba06ed4
https://gyazo.com/7fc7058cef2d722aa24ad3c9f9f3a755
https://gyazo.com/877395507806e55ea43adc24a246573f
https://gyazo.com/60df985fb8cf76fdf0e09bdc34f346d2
https://gyazo.com/09f9b345cf1dac1824caed6199e8d9c5